### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+genext2fs (1.4.1-5) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 01:56:07 +0100
+
 genext2fs (1.4.1-4) unstable; urgency=low
 
   * debian/patches/byteswap_fix.diff: New patch by Samuel Thibault,

--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: genext2fs
 Section: admin
 Priority: optional
 Maintainer: Jérémie Koenig <jk@jk.fr.eu.org>
-Vcs-Git: git://github.com/jeremie-koenig/genext2fs.git
-Vcs-Browser: http://github.com/jeremie-koenig/genext2fs
+Vcs-Git: https://github.com/jeremie-koenig/genext2fs.git
+Vcs-Browser: https://github.com/jeremie-koenig/genext2fs
 Build-Depends: debhelper (>> 8), autoconf (>= 2.59), automake (>= 1.10)
 Build-Conflicts: autoconf2.13
 Standards-Version: 3.9.2


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
